### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-run-and-push.yml
+++ b/.github/workflows/python-run-and-push.yml
@@ -15,6 +15,8 @@ jobs:
   build:
     # Display name of the job in the GitHub Actions UI
     name: Execute main.go and Push Changes
+    permissions:
+      contents: write
     # Specify the type of runner (a fresh Ubuntu VM)
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Potential fix for [https://github.com/Strong-Foundation/buckeyeinternational-com-documentation/security/code-scanning/1](https://github.com/Strong-Foundation/buckeyeinternational-com-documentation/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow, specifying the minimal required permissions for the GITHUB_TOKEN. Since the workflow pushes changes to the repository, it needs `contents: write` permission. The best way to do this is to add the `permissions` block at the job level (under `build:`), so it only applies to this job. Alternatively, you could add it at the workflow root if you want it to apply to all jobs. In this case, since there is only one job, either location is acceptable, but job-level is more precise. You should add the following block under the `build:` job, before `runs-on:`:

```yaml
permissions:
  contents: write
```

No additional imports or definitions are needed, as this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
